### PR TITLE
Add support for dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-API_ROOT=https://conduit.productionready.io/apia
+API_ROOT=https://conduit.productionready.io/api

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+API_ROOT=https://conduit.productionready.io/apia

--- a/crates/conduit-wasm/Cargo.toml
+++ b/crates/conduit-wasm/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
-name = "conduit-wasm"
-version = "0.1.0"
 authors = ["Jet Li <jing.i.qin@icloud.com>"]
+categories = ["wasm"]
+description = "Exemplary real world app built with Rust + Yew + WebAssembly."
 edition = "2018"
+license = "Apache-2.0/MIT"
+name = "conduit-wasm"
+repository = "https://github.com/jetli/rust-yew-realworld-example-app.git"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 chrono = { version = "0.4.10", features = ["serde"] }
+dotenv_codegen = "0.15.0"
 failure = "0.1.6"
 lazy_static = "1.4.0"
 log = "0.4.8"

--- a/crates/conduit-wasm/build.rs
+++ b/crates/conduit-wasm/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    //println!("cargo:rerun-if-env-changed=API_ROOT");
+    println!("cargo:rerun-if-changed=../../.env");
+}

--- a/crates/conduit-wasm/src/agent.rs
+++ b/crates/conduit-wasm/src/agent.rs
@@ -2,6 +2,7 @@
 
 #![allow(dead_code)]
 
+use dotenv_codegen::dotenv;
 use lazy_static::lazy_static;
 use log::debug;
 use parking_lot::RwLock;
@@ -15,7 +16,7 @@ use yew::services::storage::{Area, StorageService};
 use crate::error::Error;
 use crate::types::*;
 
-const API_ROOT: &str = "https://conduit.productionready.io/api";
+const API_ROOT: &str = dotenv!("API_ROOT");
 const TOKEN_KEY: &str = "yew.token";
 
 lazy_static! {


### PR DESCRIPTION
Fix https://github.com/jetli/rust-yew-realworld-example-app/issues/7

but new value of API_ROOT is not picked up when editing .env file, not sure why now.