### PR TITLE
Fix building with newer wasm-bindgen installed

### DIFF
--- a/crates/conduit-wasm/Cargo.toml
+++ b/crates/conduit-wasm/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0.44"
 thiserror = "1"
 yew = "0.17.3"
 yew-router = { version="0.14.0", features = ["web_sys"] }
-wasm-bindgen = "0.2.63"
+wasm-bindgen = "0.2"
 wasm-logger = "0.2.0"
 wee_alloc = "0.4.5"
 


### PR DESCRIPTION
wasm-pack somehow wants the exact version listed in Cargo.toml, this breaks building if a newer wasm-bindgen point-release is installed. This PR relaxes the requirement.