### PR TITLE
Handle null author image

### DIFF
--- a/crates/conduit-wasm/src/components/article_preview.rs
+++ b/crates/conduit-wasm/src/components/article_preview.rs
@@ -89,7 +89,7 @@ impl Component for ArticlePreview {
         html! {
             <div class="article-preview">
                 <div class="article-meta">
-                    <img src={ &article.author.image } />
+                    <img src={ if article.author.image.is_none() { "" } else { article.author.image.as_ref().unwrap() }} /> 
                     <div class="info">
                         <RouterAnchor<AppRoute>
                             route=AppRoute::Profile(article.author.username.clone())

--- a/crates/conduit-wasm/src/routes/article/article_meta.rs
+++ b/crates/conduit-wasm/src/routes/article/article_meta.rs
@@ -39,8 +39,8 @@ impl Component for ArticleMeta {
     fn view(&self) -> Html {
         html! {
             <div class="article-meta">
-                <img src={ &self.props.author.image } alt={ &self.props.author.username } />
-
+                <img src={ if self.props.author.image.is_none() { "" } else { self.props.author.image.as_ref().unwrap() }}
+                    alt={ &self.props.author.username } />
                 <div class="info">
                     <RouterAnchor<AppRoute> route=AppRoute::Profile(self.props.author.username.clone()) classes="author" >
                         { &self.props.author.username }

--- a/crates/conduit-wasm/src/routes/article/comment.rs
+++ b/crates/conduit-wasm/src/routes/article/comment.rs
@@ -51,7 +51,8 @@ impl Component for Comment {
                 </div>
                 <div class="card-footer">
                     <span class="comment-author">
-                        <img src={ &comment.author.image } class="comment-author-img" alt={ &comment.author.username } />
+                        <img src={ if comment.author.image.is_none() { "" } else { comment.author.image.as_ref().unwrap() }} 
+                            class="comment-author-img" alt={ &comment.author.username } />
                     </span>
                     { " " }
                     <RouterAnchor<AppRoute> route=AppRoute::Profile(comment.author.username.clone()) classes="comment-author">

--- a/crates/conduit-wasm/src/routes/profile.rs
+++ b/crates/conduit-wasm/src/routes/profile.rs
@@ -106,7 +106,8 @@ impl Component for Profile {
                         <div class="container">
                             <div class="row">
                                 <div class="col-xs-12 col-md-10 offset-md-1">
-                                    <img src={ &profile.image } class="user-img" alt={ &profile.username } />
+                                    <img src={ if profile.image.is_none() { "" } else { profile.image.as_ref().unwrap() }} 
+                                         class="user-img" alt={ &profile.username } />
                                     <h4>{ &profile.username }</h4>
                                     <p>
                                         {

--- a/crates/conduit-wasm/src/types/profiles.rs
+++ b/crates/conduit-wasm/src/types/profiles.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct ProfileInfo {
     pub username: String,
     pub bio: Option<String>,
-    pub image: String,
+    pub image: Option<String>,
     pub following: bool,
 }
 


### PR DESCRIPTION
Some realworld servers return null for the image field on the author json if it hasn't been set. One example is the Rust based [realworld-tide](https://github.com/colinbankier/realworld-tide) server. If you create a new profile with that server and this UI before these changes, you'll get a "Deserialize Error". With this patch the author image field changes from a `String` to an `Option<String>`, like bio already is, and the html uses "" for the image source if it is null.