### PR TITLE
Corrected minor spelling errors

### DIFF
--- a/crates/conduit-wasm/src/hooks/use_user_context.rs
+++ b/crates/conduit-wasm/src/hooks/use_user_context.rs
@@ -9,12 +9,12 @@ use crate::services::set_token;
 use crate::types::UserInfo;
 
 /// State handle for the [`use_user_context`] hook.
-pub struct UseUserConextHandle {
+pub struct UseUserContextHandle {
     inner: UseStateHandle<UserInfo>,
     history: AnyHistory,
 }
 
-impl UseUserConextHandle {
+impl UseUserContextHandle {
     pub fn login(&self, value: UserInfo) {
         // Set global token after logged in
         set_token(Some(value.token.clone()));
@@ -32,7 +32,7 @@ impl UseUserConextHandle {
     }
 }
 
-impl Deref for UseUserConextHandle {
+impl Deref for UseUserContextHandle {
     type Target = UserInfo;
 
     fn deref(&self) -> &Self::Target {
@@ -40,7 +40,7 @@ impl Deref for UseUserConextHandle {
     }
 }
 
-impl Clone for UseUserConextHandle {
+impl Clone for UseUserContextHandle {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -49,24 +49,24 @@ impl Clone for UseUserConextHandle {
     }
 }
 
-impl PartialEq for UseUserConextHandle {
+impl PartialEq for UseUserContextHandle {
     fn eq(&self, other: &Self) -> bool {
         *self.inner == *other.inner
     }
 }
 
-impl fmt::Debug for UseUserConextHandle {
+impl fmt::Debug for UseUserContextHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("UseUserConextHandle")
+        f.debug_struct("UseUserContextHandle")
             .field("value", &format!("{:?}", *self.inner))
             .finish()
     }
 }
 
 /// This hook is used to manage user context.
-pub fn use_user_context() -> UseUserConextHandle {
+pub fn use_user_context() -> UseUserContextHandle {
     let inner = use_context::<UseStateHandle<UserInfo>>().unwrap();
     let history = use_history().unwrap();
 
-    UseUserConextHandle { inner, history }
+    UseUserContextHandle { inner, history }
 }

--- a/crates/conduit-wasm/src/routes/article/comment_input.rs
+++ b/crates/conduit-wasm/src/routes/article/comment_input.rs
@@ -14,7 +14,7 @@ pub struct Props {
     pub callback: Callback<CommentInfo>,
 }
 
-/// Creat a comment for an article.
+/// Create a comment for an article.
 #[function_component(CommentInput)]
 pub fn comment_input(props: &Props) -> Html {
     let create_info = use_state(CommentCreateInfo::default);


### PR DESCRIPTION
I noticed a couple places where it was `Conext` instead of `Context`, or `Creat` instead of `Create`.