### PR TITLE
Fix pagination and favorite

### DIFF
--- a/crates/conduit-wasm/src/components/article_list.rs
+++ b/crates/conduit-wasm/src/components/article_list.rs
@@ -72,6 +72,14 @@ pub fn article_list(props: &Props) -> Html {
         )
     };
 
+    let loading = html! {
+        <div class="article-preview">{ "Loading..." }</div>
+    };
+
+    if article_list.loading {
+        return loading;
+    }
+
     if let Some(article_list) = &article_list.data {
         if !article_list.articles.is_empty() {
             html! {
@@ -91,8 +99,6 @@ pub fn article_list(props: &Props) -> Html {
             }
         }
     } else {
-        html! {
-            <div class="article-preview">{ "Loading..." }</div>
-        }
+        loading
     }
 }

--- a/crates/conduit-wasm/src/components/article_preview.rs
+++ b/crates/conduit-wasm/src/components/article_preview.rs
@@ -2,6 +2,7 @@ use yew::prelude::*;
 use yew_hooks::prelude::*;
 use yew_router::prelude::*;
 
+use crate::hooks::use_user_context;
 use crate::routes::AppRoute;
 use crate::services::articles::*;
 use crate::types::ArticleInfo;
@@ -48,10 +49,19 @@ pub fn article_preview(props: &Props) -> Html {
     } else {
         NOT_FAVORITED_CLASS
     };
+
+    let user_ctx = use_user_context();
     let onclick = {
-        Callback::from(move |ev: MouseEvent| {
-            ev.prevent_default();
-            article_favorite.run();
+        let navigator = use_navigator().unwrap();
+        let article_favorite = article_favorite.clone();
+
+        Callback::from(move |e: MouseEvent| {
+            e.prevent_default();
+            if user_ctx.is_authenticated() {
+                article_favorite.run();
+            } else {
+                navigator.push(&AppRoute::Login);
+            }
         })
     };
 

--- a/crates/conduit-wasm/src/services/articles.rs
+++ b/crates/conduit-wasm/src/services/articles.rs
@@ -24,7 +24,14 @@ pub async fn del(slug: String) -> Result<DeleteWrapper, Error> {
 
 /// Favorite and article
 pub async fn favorite(slug: String) -> Result<ArticleInfoWrapper, Error> {
-    request_post::<(), ArticleInfoWrapper>(format!("/articles/{}/favorite", slug), ()).await
+    // Workaround: null POST body is rejected by the default API backend
+    use serde::{Serialize, Deserialize};
+    #[derive(Serialize, Deserialize, Debug, Default)]
+    struct Slug {
+        slug: String,
+    }
+
+    request_post::<Slug, ArticleInfoWrapper>(format!("/articles/{}/favorite", slug), Slug { slug }).await
 }
 
 /// Unfavorite an article


### PR DESCRIPTION
- Pagination
  - Prompt "loading..." if article_list is being retrieved, which accidentally solves the issue in pagination.

- Favorite
  - Route to login page if user is not logged in.
  - Use dummy post body for API request, as the default API backend rejects "null" json.